### PR TITLE
Improve portfolio styling

### DIFF
--- a/app/static/app/css/about.css
+++ b/app/static/app/css/about.css
@@ -20,14 +20,14 @@
 }
 
 h3 {
-    color: #1a365d;
-    border-bottom: 2px solid #4299e1;
+    color: var(--primary-color);
+    border-bottom: 2px solid #1976d2;
     padding-bottom: 10px;
     margin-bottom: 20px;
 }
 
 .skill-tag {
-    background: #4299e1;
+    background: #1976d2;
     color: white;
     padding: 5px 10px;
     border-radius: 15px;
@@ -39,7 +39,7 @@ h3 {
     font-size: 2.5rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin: 2rem 0;
@@ -56,7 +56,7 @@ h3 {
     transform: translateX(-50%);
     width: 100px;
     height: 4px;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     border-radius: 2px;
 }
 
@@ -93,7 +93,7 @@ h3 {
     content: "";
     position: absolute;
     width: 3px;
-    background: #4299e1;
+    background: #1976d2;
     top: 0;
     bottom: 0;
     left: 50%;
@@ -113,7 +113,7 @@ h3 {
     width: 20px;
     height: 20px;
     right: -10px;
-    background-color: #4299e1;
+    background-color: #1976d2;
     border: 4px solid #fff;
     top: 15px;
     border-radius: 50%;
@@ -260,15 +260,13 @@ h3 {
     display: grid;
     grid-template-columns: 300px 1fr;
     gap: 2rem;
-    background: rgba(255,
-            255,
-            255,
-            0.7);
+    background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(245,247,250,0.9));
     backdrop-filter: blur(10px);
     border-radius: 15px;
     padding: 2rem;
     margin-top: 20px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(230,235,240,0.9);
 }
 
 .profile-image-container {
@@ -318,7 +316,7 @@ h3 {
 }
 
 .highlight-text {
-    background: linear-gradient(120deg, #63b3ed 0%, #4299e1 100%);
+    background: linear-gradient(120deg, #64b5f6 0%, #1976d2 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     font-weight: bold;
@@ -364,7 +362,7 @@ h3 {
 
 .intro-text div p {
     font-weight: 600;
-    color: #1a365d;
+    color: var(--primary-color);
     margin-bottom: 10px;
     border-bottom: 2px solid rgba(66, 153, 225, 0.2);
     padding-bottom: 5px;
@@ -419,7 +417,7 @@ h3 {
 .vision-header {
     font-size: 1.8rem;
     margin-bottom: 1rem;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     font-weight: bold;
@@ -444,7 +442,7 @@ h3 {
     background: rgba(66, 153, 225, 0.1);
     border-radius: 12px;
     transition: all 0.3s ease;
-    border-left: 4px solid #4299e1;
+    border-left: 4px solid #1976d2;
 }
 
 .vision-list li:hover {
@@ -478,11 +476,11 @@ h3 {
     font-size: 2rem;
     font-weight: 600;
     text-align: center;
-    color: #1a365d;
+    color: var(--primary-color);
     margin: 1.5rem 0;
     padding-bottom: 0.5rem;
     position: relative;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -491,7 +489,7 @@ h3 {
     font-size: 1.8rem;
     font-weight: bold;
     margin-bottom: 1rem;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     text-align: center;

--- a/app/static/app/css/achievements.css
+++ b/app/static/app/css/achievements.css
@@ -31,7 +31,7 @@
     font-size: 2.5rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin:  0;
@@ -48,7 +48,7 @@
     transform: translateX(-50%);
     width: 100px;
     height: 4px;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     border-radius: 2px;
 }
 
@@ -61,11 +61,11 @@
 
 .section-title {
     font-size: 2rem;
-    color: #1a365d;
+    color: var(--primary-color);
     margin-bottom: 1.5rem;
     text-align: center;
     position: relative;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -75,6 +75,7 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1.5rem;
     padding: 1rem;
+    grid-auto-rows: 1fr;
 }
 
 .achievement-card {
@@ -88,6 +89,8 @@
     max-width: 400px;
     margin: 0 auto;
     width: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .achievement-card:hover {
@@ -124,10 +127,13 @@
 
 .card-content {
     padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
 }
 
 .card-content h3 {
-    color: #1a365d;
+    color: var(--primary-color);
     margin-bottom: 0.5rem;
     font-size: 1.4rem;
 }
@@ -143,13 +149,14 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     color: white;
     padding: 0.8rem 1.5rem;
     border-radius: 8px;
     text-decoration: none;
     transition: all 0.3s ease;
     font-weight: 500;
+    margin-top: auto;
 }
 
 .link-btn:hover {

--- a/app/static/app/css/contact.css
+++ b/app/static/app/css/contact.css
@@ -1,11 +1,11 @@
 :root {
-    --primary-color: #1a365d;     /* Deep blue */
-    --secondary-color: #4299e1;   /* Medium blue */
-    --accent-color: #63b3ed;      /* Light blue */
-    --background-color: #f7fafc;  /* Very light blue/white */
-    --text-color: #2d3748;        /* Dark blue-gray */
+    --primary-color: #0d47a1;     /* Navy Blue */
+    --secondary-color: #1976d2;   /* Soft Blue */
+    --accent-color: #64b5f6;      /* Light Blue */
+    --background-color: #f5f7fa;  /* Light Gray */
+    --text-color: #273043;        /* Dark Gray */
     --card-background: #ffffff;
-    --gradient: linear-gradient(135deg, #1a365d, #4299e1);
+    --gradient: linear-gradient(135deg, #0d47a1, #1976d2);
 }
 
 body {
@@ -78,7 +78,7 @@ body {
 }
 
 .submit-btn {
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     color: white;
     padding: 15px 30px;
     border: none;
@@ -106,7 +106,7 @@ body {
 
 .contact-form-header h3 {
     font-size: 2rem;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin-bottom: 10px;
@@ -138,7 +138,7 @@ body {
     left: 0;
     width: 4px;
     height: 100%;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     transition: all 0.3s ease;
 }
 
@@ -162,7 +162,7 @@ body {
 
 .contact-card:hover .contact-icon {
     transform: scale(1.1);
-    color: #1a365d;
+    color: var(--primary-color);
 }
 
 .contact-card h3 {
@@ -178,7 +178,7 @@ body {
 }
 
 .contact-card a {
-    color: #4299e1;
+    color: var(--secondary-color);
     text-decoration: none;
     display: block;
     margin: 8px 0;
@@ -188,7 +188,7 @@ body {
 }
 
 .contact-card a:hover {
-    color: #1a365d;
+    color: var(--primary-color);
     transform: translateX(5px);
 }
 
@@ -221,7 +221,7 @@ body {
     font-size: 2.5rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin: 2rem 0;
@@ -238,7 +238,7 @@ body {
     transform: translateX(-50%);
     width: 100px;
     height: 4px;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     border-radius: 2px;
 }
 

--- a/app/static/app/css/layout.css
+++ b/app/static/app/css/layout.css
@@ -1,17 +1,17 @@
 :root {
-    --primary-color: #1a365d;     /* Deep blue */
-    --secondary-color: #4299e1;   /* Medium blue */
-    --accent-color: #63b3ed;      /* Light blue */
-    --background-color: #f7fafc;  /* Very light blue/white */
-    --text-color: #2d3748;        /* Dark blue-gray */
+    --primary-color: #0d47a1;     /* Navy Blue */
+    --secondary-color: #1976d2;   /* Soft Blue */
+    --accent-color: #64b5f6;      /* Light Blue */
+    --background-color: #f5f7fa;  /* Light Gray */
+    --text-color: #273043;        /* Dark Gray */
     --card-background: #ffffff;
-    --gradient: linear-gradient(135deg, #1a365d, #4299e1);
+    --gradient: linear-gradient(135deg, #0d47a1, #1976d2);
     --nav-dropdown-bg: rgba(255, 255, 255, 0.98);
     --nav-dropdown-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
     --transition-slow: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
     --transition-medium: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
     --transition-fast: all 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
-    --nav-gradient: linear-gradient(to right, #1a365d, #2b6cb0, #4299e1);
+    --nav-gradient: linear-gradient(to right, #0d47a1, #1976d2, #64b5f6);
     --nav-glass-bg: rgba(255, 255, 255, 0.1);
     --nav-glass-border: rgba(255, 255, 255, 0.2);
     --nav-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);

--- a/app/static/app/css/main.css
+++ b/app/static/app/css/main.css
@@ -1,11 +1,11 @@
 :root {
-    --primary-color: #1a365d;     /* Deep blue */
-    --secondary-color: #4299e1;   /* Medium blue */
-    --accent-color: #63b3ed;      /* Light blue */
-    --background-color: #f7fafc;  /* Very light blue/white */
-    --text-color: #2d3748;        /* Dark blue-gray */
-    --card-background: #ffffff;  
-    --gradient: linear-gradient(135deg, #1a365d, #4299e1);
+    --primary-color: #0d47a1;     /* Navy Blue */
+    --secondary-color: #1976d2;   /* Soft Blue */
+    --accent-color: #64b5f6;      /* Light Blue */
+    --background-color: #f5f7fa;  /* Light Gray */
+    --text-color: #273043;        /* Dark Gray */
+    --card-background: #ffffff;
+    --gradient: linear-gradient(135deg, #0d47a1, #1976d2);
     --box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
     --transition-smooth: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
 }
@@ -34,7 +34,7 @@ body {
     font-size: 2.5rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin: 2rem 0;
@@ -52,7 +52,7 @@ body {
     transform: translateX(-50%);
     width: 80px;
     height: 4px;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     border-radius: 2px;
 }
 

--- a/app/static/app/css/skills.css
+++ b/app/static/app/css/skills.css
@@ -29,17 +29,13 @@
     right: 0;
     width: 100%;
     height: 5px;
-    background: linear-gradient(90deg,
-            #1a365d,
-            #4299e1);
+    background: var(--gradient);
     opacity: 0.8;
 }
 
 .skill-icon {
     font-size: 3.5rem;
-    background: linear-gradient(135deg,
-            #1a365d,
-            #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin-bottom: 2rem;
@@ -50,9 +46,7 @@
     font-size: 1.75rem;
     font-weight: 700;
     margin-bottom: 2rem;
-    background: linear-gradient(135deg,
-            #1a365d,
-            #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -120,9 +114,7 @@
 .skill-item:hover {
     transform: translateY(-3px) scale(1.05);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-    background: linear-gradient(135deg,
-            #1a365d,
-            #4299e1);
+    background: var(--gradient);
     color: white;
 }
 
@@ -135,7 +127,7 @@
     font-size: 2.5rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     margin: 2rem 0;
@@ -153,7 +145,7 @@
     transform: translateX(-50%);
     width: 100px;
     height: 4px;
-    background: linear-gradient(45deg, #1a365d, #4299e1);
+    background: var(--gradient);
     border-radius: 2px;
 }
 

--- a/app/static/app/scripts/layout.js
+++ b/app/static/app/scripts/layout.js
@@ -87,6 +87,7 @@ function initNavigation() {
   // Dropdown functionality
   const navDropdown = document.querySelector('.nav-dropdown');
   const dropdownButton = document.querySelector('.dropdown-button');
+  const dropdownLinks = document.querySelectorAll('.dropdown-link');
   
   if (dropdownButton) {
     dropdownButton.addEventListener('click', function(e) {
@@ -94,6 +95,13 @@ function initNavigation() {
       navDropdown.classList.toggle('active');
     });
   }
+
+  // Close dropdown when a link is clicked
+  dropdownLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      navDropdown.classList.remove('active');
+    });
+  });
   
   // Close dropdown when clicking outside
   document.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- refresh colour palette in layout and page styles
- keep about page intro visually engaging
- ensure achievement cards line up
- close dropdown after selecting a link

## Testing
- `pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68824797217083289739468bffb3ac95